### PR TITLE
Correct integration test, make canary deployment shorter and make default lambda correct

### DIFF
--- a/integration_test/test_service.test.ts
+++ b/integration_test/test_service.test.ts
@@ -1,22 +1,17 @@
+/**
+ * @jest-environment node
+ */
+
 import axios from 'axios';
 
 test('200 Response', async () => {
-    console.log('env ->', process.env);
+  // Arrange
+  const url = process.env.SERVICE_URL ?? 'No SERVICE_URL in env';
+  console.log('url ->', url);
 
-    const url = process.env.SERVICE_URL ?? 'No SERVICE_URL in env'
-    console.log('url ->', url);
+  // Act
+  const response = await axios.get(url);
 
-    // TODO: Figure out why CORS on API isn't working
-    //
-    // await axios.request({
-    //     url
-    // }).then(response => {
-    //     console.log('response ->', response);
-
-    //     expect(response.status).toEqual(200);
-    // }).catch(error => {
-    //     console.log('error ->', error);
-
-    //     fail(error);
-    // });
+  // Assert
+  expect(response.status).toEqual(200);
 });

--- a/pipelines_webinar/lambda/handler.ts
+++ b/pipelines_webinar/lambda/handler.ts
@@ -1,8 +1,8 @@
-const AWS = require("aws-sdk");
+const AWS = require('aws-sdk');
 
 export const handler = async (event: any = {}): Promise<any> => {
   return {
-    body: "Hello",
+    body: 'Hello',
     statusCode: 200,
   };
 };

--- a/pipelines_webinar/lambda/handler.ts
+++ b/pipelines_webinar/lambda/handler.ts
@@ -1,8 +1,8 @@
-const AWS = require('aws-sdk');
+const AWS = require("aws-sdk");
 
 export const handler = async (event: any = {}): Promise<any> => {
-    return {
-        body: 'Broken',
-        statusCode: 500,
-    };
+  return {
+    body: "Hello",
+    statusCode: 200,
+  };
 };

--- a/pipelines_webinar/lambda/handler.ts
+++ b/pipelines_webinar/lambda/handler.ts
@@ -1,8 +1,6 @@
-const AWS = require('aws-sdk');
-
 export const handler = async (event: any = {}): Promise<any> => {
   return {
-    body: 'Hello',
+    body: 'Hello from the Lambda',
     statusCode: 200,
   };
 };

--- a/pipelines_webinar/pipelines_webinar_stack.ts
+++ b/pipelines_webinar/pipelines_webinar_stack.ts
@@ -1,8 +1,14 @@
 import path = require('path');
-import { CfnOutput, Construct, Duration, Stack, StackProps } from '@aws-cdk/core';
-import * as lambda from '@aws-cdk/aws-lambda'
-import * as apigw from '@aws-cdk/aws-apigateway'
-import * as codedeploy from '@aws-cdk/aws-codedeploy'
+import {
+  CfnOutput,
+  Construct,
+  Duration,
+  Stack,
+  StackProps,
+} from '@aws-cdk/core';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as apigw from '@aws-cdk/aws-apigateway';
+import * as codedeploy from '@aws-cdk/aws-codedeploy';
 import * as cloudwatch from '@aws-cdk/aws-cloudwatch';
 
 export class PipelinesWebinarStack extends Stack {
@@ -19,7 +25,7 @@ export class PipelinesWebinarStack extends Stack {
 
     const alias = new lambda.Alias(this, 'x', {
       aliasName: 'Current',
-      version: handler.currentVersion
+      version: handler.currentVersion,
     });
 
     const api = new apigw.LambdaRestApi(this, 'Gateway', {
@@ -31,10 +37,10 @@ export class PipelinesWebinarStack extends Stack {
       metricName: '5XXError',
       namespace: 'AWS/ApiGateway',
       dimensions: {
-        ApiName: 'Gateway'
+        ApiName: 'Gateway',
       },
       statistic: 'Sum',
-      period: Duration.minutes(1)
+      period: Duration.minutes(1),
     });
     const failureAlarm = new cloudwatch.Alarm(this, 'RollbackAlarm', {
       metric: apiGateway5xx,
@@ -44,10 +50,9 @@ export class PipelinesWebinarStack extends Stack {
 
     new codedeploy.LambdaDeploymentGroup(this, 'DeploymentGroup ', {
       alias,
-      deploymentConfig: codedeploy.LambdaDeploymentConfig.CANARY_10PERCENT_10MINUTES,
-      alarms: [
-        failureAlarm
-      ]
+      deploymentConfig:
+        codedeploy.LambdaDeploymentConfig.CANARY_10PERCENT_5MINUTES,
+      alarms: [failureAlarm],
     });
 
     this.urlOutput = new CfnOutput(this, 'url', { value: api.url });


### PR DESCRIPTION
1. Correct integration test to work correctly locally and in the pipeline. Actually, the one missing thing was the 
```
/**
 * @jest-environment node
 */
```
at the top of the file.
2. Change canary deployment time from 10 to 5 minutes to run this sample faster.
3. The default Lambda function used in this sample should return HTTP 200 rather than 500 to run it smoothly for the first time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
